### PR TITLE
init.pp: force creation of app folder before the library folder. vcsr…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,8 @@ class igo (
       ensure  => 'link',
       target  => '/vagrant',
       force   => true,
-      require => File[$igoRootPath]
+      require => File[$igoRootPath],
+      before  => Vcsrepo["${igoAppPath}/librairie"],
     }
     $requiredIgoAppPath = File[$igoAppPath]
   } else {
@@ -64,6 +65,7 @@ class igo (
         Package['git'],
         File[$igoRootPath],
       ],
+      before   => Vcsrepo["${igoAppPath}/librairie"],
     }
     $requiredIgoAppPath = Vcsrepo[$igoAppPath]
   }


### PR DESCRIPTION
Problème d'ordonnancement. Lors de l’exécution du script Puppet, le répertoire ${igoAppPath}/librairie (/var/igo/igo/librairie) se créait avant de créer le répertoire ${igoAppPath} (/var/igo/igo). L'ajout d'énoncés before dans la condition $usedByVagrant pour pallier au problème.